### PR TITLE
Add more codecs into comps

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -35,6 +35,8 @@
       <packagereq type="optional">pipewire-codec-aptx</packagereq>
       <packagereq type="optional">xpra-codecs-freeworld</packagereq>
       <packagereq type="optional">vlc-plugins-freeworld</packagereq>
+      <packagereq type="default">gstreamer1-plugins-ugly</packagereq>
+      <packagereq type="default">nv-codec-headers</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps.xml
+++ b/comps.xml
@@ -27,6 +27,14 @@
       <packagereq type="default">sipa-fonts</packagereq>
       <packagereq type="default">ibus-mozc</packagereq>
       <packagereq type="default">mozc</packagereq>
+      <packagereq type="default">x264</packagereq>
+      <packagereq type="default">x265</packagereq>
+      <packagereq type="default">flac</packagereq>
+      <packagereq type="optional">lame</packagereq>
+      <packagereq type="default">opus</packagereq>
+      <packagereq type="optional">pipewire-codec-aptx</packagereq>
+      <packagereq type="optional">xpra-codecs-freeworld</packagereq>
+      <packagereq type="optional">vlc-plugins-freeworld</packagereq>
     </packagelist>
   </group>
   <group>

--- a/ultramarine/kde-settings/kde-settings.spec
+++ b/ultramarine/kde-settings/kde-settings.spec
@@ -42,6 +42,13 @@ Requires: breeze-icon-theme
 %description
 %{summary}.
 
+%package sddm
+Summary: Configuration files for sddm
+Requires: sddm
+Requires: breeze-cursor-theme
+%description sddm
+%{summary}.
+
 %package plasma
 Summary: Configuration files for plasma
 Requires: %{name} = %{epoch}:%{version}-%{release}
@@ -171,7 +178,6 @@ test -f %{_datadir}/wallpapers/F%{version_maj} || ls -l %{_datadir}/wallpapers
 %{_prefix}/lib/rpm/plasma4.prov
 %{_prefix}/lib/rpm/plasma4.req
 %{_prefix}/lib/rpm/fileattrs/plasma4.attr
-%{_prefix}/lib/sddm/sddm.conf.d/kde_settings.conf
 %{_datadir}/polkit-1/rules.d/11-fedora-kde-policy.rules
 %config(noreplace) %{_sysconfdir}/xdg/kcm-about-distrorc
 %config(noreplace) %{_sysconfdir}/xdg/kdebugrc
@@ -185,6 +191,9 @@ test -f %{_datadir}/wallpapers/F%{version_maj} || ls -l %{_datadir}/wallpapers
 %exclude %{_datadir}/kde-settings/kde-profile/default/share/apps/plasma-desktop/init/00-defaultLayout.js
 %exclude /.package_note*
 %endif
+
+%files sddm
+%{_prefix}/lib/sddm/sddm.conf.d/kde_settings.conf
 
 %files plasma
 %{_datadir}/plasma/shells/org.kde.plasma.desktop/contents/updates/00-start-here-2.js


### PR DESCRIPTION
This pull request adds additional codecs (x264, x265, flac, lame, opus, pipewire-codec-aptx, xpra-codecs-freeworld, vlc-plugins-freeworld) into the comps file.