### PR TITLE
Add keybinds for deleting words with Ctrl and Alt

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -10,6 +10,14 @@ source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 bindkey "^[[1;5D" backward-word
 bindkey "^[[1;5C" forward-word
 
+# Ctrl + Backspace/Delete Kebindings
+bindkey '^H' backward-kill-word
+bindkey '^[[3;5~' kill-word
+
+# ALt + Backspack/Delete Keybinds
+bindkey "^[[3~" delete-char
+bindkey -M emacs '^[[3;3~' kill-word
+
 HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000

--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -14,7 +14,7 @@ bindkey "^[[1;5C" forward-word
 bindkey '^H' backward-kill-word
 bindkey '^[[3;5~' kill-word
 
-# ALt + Backspack/Delete Keybinds
+# ALt + Backspace/Delete Keybinds
 bindkey "^[[3~" delete-char
 bindkey -M emacs '^[[3;3~' kill-word
 


### PR DESCRIPTION
By default in ZSH, **Alt** + **Arrows** moves by one word. This change makes it so that **Ctrl**/**Alt** + **Backspace**/**Delete** deletes a word, as the convention is outside of the shell.

This change saves a lot of time, and it is not intuitive for new users to figure out how to do this configuration on their own.