### PR TITLE
Change Syntax Highlighting plugin to fast-syntax-highlighting

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -12,7 +12,7 @@ Source3:        ultramarine-shell.sh
 Source4:        starship.toml
 
 Requires:       zsh-autosuggestions
-Requires:       zsh-syntax-highlighting
+Requires:       F-Sy-H
 Requires:       bat
 Requires:       starship
 

--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -3,7 +3,7 @@
 # initialize starship
 eval "$(starship init zsh)"
 
-source /usr/share/F-Sy-H/F-Sy-H.plugin.zsh 
+source /usr/share/F-Sy-H/F-Sy-H.plugin.zsh
 source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Ctrl + Arrow keybindings

--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -3,7 +3,7 @@
 # initialize starship
 eval "$(starship init zsh)"
 
-source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source /usr/share/F-Sy-H/F-Sy-H.plugin.zsh 
 source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Ctrl + Arrow keybindings


### PR DESCRIPTION
F-Sy-H is a far better alternative to zsh-syntax-highlighting. It has not only better syntax highlighting, but it is mush less buggy.