### PR TITLE
Remove unnecessary tmpfiles config in favor of saner defaults

### DIFF
--- a/ultramarine/ultramarine-system-configs/tmpfiles-cleanup.conf
+++ b/ultramarine/ultramarine-system-configs/tmpfiles-cleanup.conf
@@ -1,2 +1,0 @@
-# remove files in /var/tmp older than 10 days
-D /var/tmp 1777 root root 10d

--- a/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
+++ b/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-system-configs
-Version:        1
+Version:        1.1
 Release:        1%{?dist}
 Summary:        Various configuration files for a more comfortable Ultramarine desktop experience
 BuildArch:      noarch

--- a/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
+++ b/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
@@ -5,7 +5,6 @@ Summary:        Various configuration files for a more comfortable Ultramarine d
 BuildArch:      noarch
 License:        MIT
 URL:            https://ultramarine-linux.org
-Source1:        tmpfiles-cleanup.conf
 Source2:        ultramarine-logrotate.conf
 Source3:        networking-tweaks.conf
 Source4:        bbr.conf
@@ -42,7 +41,6 @@ cleaning up of unused temporary files periodically.
 
 
 %install
-install -Dm644 %{SOURCE1} %{buildroot}/etc/tmpfiles.d/tmpfiles-cleanup.conf
 install -Dm644 %{SOURCE2} %{buildroot}/etc/logrotate.d/ultramarine-logrotate.conf
 install -Dm644 %{SOURCE3} %{buildroot}/etc/sysctl.d/50-networking-tweaks.conf
 install -Dm644 %{SOURCE4} %{buildroot}/etc/modules-load.d/bbr.conf
@@ -58,7 +56,6 @@ install -Dm644 %{SOURCE5} %{buildroot}/etc/sysctl.d/50-mtu-probing.conf
 
 %files desktop
 %defattr(-,root,root,-)
-%config /etc/tmpfiles.d/tmpfiles-cleanup.conf
 %config /etc/logrotate.d/ultramarine-logrotate.conf
 %config /etc/sysctl.d/50-mtu-probing.conf
 


### PR DESCRIPTION
Since turns out the upstream defaults already had a saner timeout of 30 days for `/var/tmp` and 10 days for `/tmp`