### PR TITLE
add KRDP to default packages

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -187,6 +187,7 @@
       <packagereq type="default">kmail</packagereq>
       <packagereq type="default">haruna</packagereq>
       <packagereq type="default">kcalc</packagereq>
+      <packagereq type="default">krdp</packagereq>
     </packagelist>
   </group>
   <environment>


### PR DESCRIPTION
Ever since Plasma 6 Krfb is broken and segfaults on startup. KRDP is a new remote desktop implementation for RDP that comes with a KCM module

This will also bring feature parity to GNOME's RDP server implementation.