### PR TITLE
ultramarine-shell: Unset STARSHIP_CONFIG when a user config exists

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -1,6 +1,6 @@
 
 Name:           ultramarine-shell-config
-Version:        1.2.5
+Version:        1.2.6
 Release:        1%{?dist}
 Summary:        Shell configuration for Ultramarine Linux
 License:        MIT

--- a/ultramarine/shell-config/ultramarine-shell.sh
+++ b/ultramarine/shell-config/ultramarine-shell.sh
@@ -78,4 +78,6 @@ fi
 if ! [ -f ~/.config/starship.toml ]; then
     # export another starship config
     export STARSHIP_CONFIG=/usr/share/ultramarine-shell-config/starship.toml
+else
+    unset STARSHIP_CONFIG
 fi


### PR DESCRIPTION
zsh saves the STARSHIP_CONFIG variable even if the user configuration file exists, meaning Starship will always use the Ultramarine config and not the user configuration. Unsetting here will default to the user configuration file when it exists.