### PR TITLE
fix: minor fixups

### DIFF
--- a/ultramarine/flagship-filesystem/40_ultramarine-budgie.gschema.override
+++ b/ultramarine/flagship-filesystem/40_ultramarine-budgie.gschema.override
@@ -1,3 +1,6 @@
+[com.solus-project.budgie-menu]
+menu-icon='ultramarine'
+
 [org.gnome.desktop.wm.preferences:Budgie]
 button-layout = 'appmenu:minimize,maximize,close'
 titlebar-font='Inter Bold 11'

--- a/ultramarine/flagship-filesystem/ultramarine-flagship-filesystem.spec
+++ b/ultramarine/flagship-filesystem/ultramarine-flagship-filesystem.spec
@@ -1,6 +1,6 @@
 Name:           ultramarine-flagship-filesystem
 Version:        41
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Assets for Ultramarine Linux Flagship
 
 License:        MIT

--- a/ultramarine/release/ultramarine-flagship.conf
+++ b/ultramarine/release/ultramarine-flagship.conf
@@ -20,3 +20,4 @@ menu_auto_hide = True
 hidden_spokes =
     NetworkSpoke
     PasswordSpoke
+    UserSpoke

--- a/ultramarine/release/ultramarine-plasma.conf
+++ b/ultramarine/release/ultramarine-plasma.conf
@@ -20,3 +20,4 @@ menu_auto_hide = True
 hidden_spokes =
     NetworkSpoke
     PasswordSpoke
+    UserSpoke

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -52,7 +52,7 @@
 Summary:	Ultramarine Linux release files
 Name:		ultramarine-release
 Version:	%{dist_version}
-Release:	15%{?dist}
+Release:	16%{?dist}
 License:	MIT
 Source0:	LICENSE
 URL:        https://ultramarine-linux.org

--- a/ultramarine/release/ultramarine-xfce.conf
+++ b/ultramarine/release/ultramarine-xfce.conf
@@ -20,3 +20,4 @@ menu_auto_hide = True
 hidden_spokes =
     NetworkSpoke
     PasswordSpoke
+    UserSpoke


### PR DESCRIPTION
Actually specify the menu icon override in the gschema override, as per [Ubuntu Budgie](https://github.com/UbuntuBudgie/budgie-desktop-environment/blob/master/schemas/25_budgie-desktop-environment.gschema.override)