### PR TITLE
add FFmpegthumbnailer to the desktop list

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -70,6 +70,7 @@
       <packagereq type="default">sipa-fonts</packagereq>
       <packagereq type="default">ibus-mozc</packagereq>
       <packagereq type="default">mozc</packagereq>
+      <packagereq type="default">ffmpegthumbnailer</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
This adds a small QoL fix addressing some inconsistencies on how desktop environments (e.g GNOME) thumbnail media files.

Plasma seems to pull this in by default, but GNOME does not because Totem does the thumbnailing, now with Showtime it seems to not be thumbnailing videos at all.

This change now pulls in FFmpeg on every desktop variant for consistency, making every XDG Thumbnailer-compatible file manager index files using ffmpegthumbnailer