### PR TITLE
fix: shell-config

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -1,7 +1,7 @@
 
 Name:           ultramarine-shell-config
 Version:        43
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Shell configuration for Ultramarine Linux
 License:        MIT
 

--- a/ultramarine/shell-config/ultramarine-shell.sh
+++ b/ultramarine/shell-config/ultramarine-shell.sh
@@ -1,7 +1,7 @@
 # Global and common shell config for Ultramarine Linux
 
 um=$(cat<<EOF
-"Try searching for this package with `dnf search` or in your edition's app store."
+"Try searching for this package with dnf search or in your edition's app store."
 EOF
 )
 tryinstall="You can install '%' to hide this message. This probably isn't what you want to do and may have unintended consequences. We aren't responsible for any breakage, thermonuclear war, death of a pet, etc that happens from here. You have been warned."

--- a/ultramarine/shell-config/ultramarine-shell.sh
+++ b/ultramarine/shell-config/ultramarine-shell.sh
@@ -1,7 +1,7 @@
 # Global and common shell config for Ultramarine Linux
 
 um=$(cat<<EOF
-"Try searching for this package with dnf search or in your edition's app store."
+Try searching for this package with dnf search or in your edition's app store.
 EOF
 )
 tryinstall="You can install '%' to hide this message. This probably isn't what you want to do and may have unintended consequences. We aren't responsible for any breakage, thermonuclear war, death of a pet, etc that happens from here. You have been warned."


### PR DESCRIPTION
`dnf search` does not show, and the test has quotes around it
<img width="651" height="73" alt="image" src="https://github.com/user-attachments/assets/c5bcebe7-54b7-4446-a28b-7c6cde93f58c" />
