### PR TITLE
chore: hardcode surface repo to 42

### DIFF
--- a/ultramarine/release/linux-surface.repo
+++ b/ultramarine/release/linux-surface.repo
@@ -1,6 +1,6 @@
 [linux-surface]
 name=Surface Kernel
-baseurl=https://pkg.surfacelinux.com/fedora/f$releasever/
+baseurl=https://pkg.surfacelinux.com/fedora/f42/
 enabled=1
 skip_if_unavailable=1
 gpgkey=https://raw.githubusercontent.com/linux-surface/linux-surface/master/pkg/keys/surface.asc

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -52,7 +52,7 @@
 Summary:	Ultramarine Linux release files
 Name:		ultramarine-release
 Version:	%{dist_version}
-Release:	20%{?dist}
+Release:	21%{?dist}
 License:	MIT
 Source0:	LICENSE
 URL:        https://ultramarine-linux.org


### PR DESCRIPTION
Surface users should not be able to update at all to 43 due to issues with surface support in linux.

We make sure that they cannot update by hardcoding the releasever to 42 for the linux-surface repo.