### PR TITLE
[um43] bump: plasma-discover (#271)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -84,7 +84,7 @@ jobs:
           subatomic-cli upload --prune \
             --server https://subatomic.fyralabs.com \
             --token ${{ secrets.SUBATOMIC_TOKEN }} \
-            um${{ matrix.version }} anda-build/rpm/rpms/*
+            um${{ matrix.version }}${{ matrix.pkg.labels['bootc'] && '-bootc' || '' }} anda-build/rpm/rpms/*
 
       - name: Upload source packages to subatomic
         if: github.event_name == 'push'

--- a/ultramarine/plasma-discover/anda.hcl
+++ b/ultramarine/plasma-discover/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "plasma-discover.spec"
 	}
+	labels {
+		bootc = 1
+	}
 }

--- a/ultramarine/plasma-discover/plasma-discover.spec
+++ b/ultramarine/plasma-discover/plasma-discover.spec
@@ -6,7 +6,7 @@
 Name:    plasma-discover
 Summary: KDE and Plasma resources management GUI
 Version: 6.5.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 License: BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only)
 URL:     https://invent.kde.org/plasma/discover


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [bump: plasma-discover (#271)](https://github.com/Ultramarine-Linux/packages/pull/271)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)