### PR TITLE
[um43] Merge pull request #277 from Ultramarine-Linux/owen/comps-repo-pkg

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -44,6 +44,7 @@
       <packagereq type="default">ultramarine-release</packagereq>
       <packagereq type="default">ultramarine-fun</packagereq>
       <packagereq type="default">ultramarine-system-configs-core</packagereq>
+      <packagereq type="default">ultramarine-repos</packagereq>
       <packagereq type="default">git</packagereq>
       <packagereq type="default">umcli</packagereq>
       <packagereq type="default">fastfetch</packagereq>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [Merge pull request #277 from Ultramarine-Linux/owen/comps-repo-pkg](https://github.com/Ultramarine-Linux/packages/pull/277)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)