### PR TITLE
Refresh default app catalogue

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -66,6 +66,7 @@
       <packagereq type="default">umcli</packagereq>
       <packagereq type="default">fastfetch</packagereq>
       <packagereq type="default">btop</packagereq>
+      <packagereq type="default">htop</packagereq>
       <packagereq type="default">linux-firmware</packagereq>
       <packagereq type="default">NetworkManager-tui</packagereq>
       <packagereq type="default">zstd</packagereq>

--- a/comps.xml
+++ b/comps.xml
@@ -19,7 +19,6 @@
     <default>false</default>
     <uservisible>true</uservisible>
     <packagelist>
-      <packagereq type="default">steam-device-rules</packagereq>
       <packagereq type="default">udev-joystick-blacklist</packagereq>
       <packagereq type="default">android-udev-rules</packagereq>
       <packagereq type="default">8bitdo-udev-rules</packagereq>

--- a/comps.xml
+++ b/comps.xml
@@ -13,6 +13,19 @@
     </packagelist>
   </group>
   <group>
+    <id>ultramarine-hardware-support</id>
+    <name>Ultramarine Hardware Support</name>
+    <description>Additional hardware support for Ultramarine products</description>
+    <default>false</default>
+    <uservisible>true</uservisible>
+    <packagelist>
+      <packagereq type="default">steam-device-rules</packagereq>
+      <packagereq type="default">udev-joystick-blacklist</packagereq>
+      <packagereq type="default">android-udev-rules</packagereq>
+      <packagereq type="default">8bitdo-udev-rules</packagereq>
+    </packagelist>
+  </group>
+  <group>
     <id>multimedia</id>
     <name>Multimedia</name>
     <description>Audio/video framework common to desktops</description>
@@ -48,7 +61,6 @@
       <packagereq type="default">git</packagereq>
       <packagereq type="default">vim</packagereq>
       <packagereq type="default">nano</packagereq>
-      <packagereq type="default">htop</packagereq>
       <packagereq type="default">rsync</packagereq>
       <packagereq type="default">dive</packagereq>
       <packagereq type="default">umcli</packagereq>
@@ -152,6 +164,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-budgie-product</groupid>
     </grouplist>
   </environment>
@@ -179,6 +192,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-budgie-product</groupid>
     </grouplist>
   </environment>
@@ -317,6 +331,7 @@
       <!-- <groupid>input-methods</groupid> While the other groups incluide this, Fedora doesn't have this group in the workstation comp, going to trust them-->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-gnome-product</groupid>
     </grouplist>
   </environment>
@@ -373,6 +388,7 @@
       <!-- We should use fcitx5 in plasma instead -->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-plasma-product</groupid>
     </grouplist>
   </environment>
@@ -402,6 +418,7 @@
       <!-- We should use fcitx5 in plasma instead -->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-plasma-product</groupid>
     </grouplist>
   </environment>
@@ -467,6 +484,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
+      <groupid>ultramarine-hardware-support</groupid>
       <groupid>ultramarine-xfce-product</groupid>
     </grouplist>
   </environment>

--- a/comps.xml
+++ b/comps.xml
@@ -53,6 +53,7 @@
       <packagereq type="default">dive</packagereq>
       <packagereq type="default">umcli</packagereq>
       <packagereq type="default">fastfetch</packagereq>
+      <packagereq type="default">btop</packagereq>
       <packagereq type="default">linux-firmware</packagereq>
       <packagereq type="default">NetworkManager-tui</packagereq>
       <packagereq type="default">zstd</packagereq>

--- a/comps.xml
+++ b/comps.xml
@@ -335,8 +335,9 @@
       <packagereq type="default">fcitx5-qt</packagereq>
       <packagereq type="default">fcitx5-configtool</packagereq>
       <packagereq type="default">kcm-fcitx5</packagereq>
+      <packagereq type="default">plasma-milou</packagereq>
       <!-- <packagereq type="default">okular</packagereq> flatpak'd -->
-      <packagereq type="default">gwenview</packagereq>
+      <packagereq type="default">koko</packagereq>
       <!-- <packagereq type="default">kamoso</packagereq> flatpak'd -->
       <!-- <packagereq type="default">kolourpaint</packagereq> flatpak'd -->
       <packagereq type="default">kate</packagereq>
@@ -510,10 +511,10 @@
     <packagelist>
       <packagereq type="default">haruna</packagereq>
       <packagereq type="default">kamoso</packagereq>
-      <packagereq type="default">kcalc</packagereq>
+      <packagereq type="default">kalk</packagereq>
       <packagereq type="default">kolourpaint</packagereq>
-      <packagereq type="default">kolourpaint</packagereq>
-      <packagereq type="default">kwrite</packagereq>
+      <packagereq type="default">plasma-browser-integration</packagereq>
+      <packagereq type="default">kate</packagereq>
       <packagereq type="default">okular</packagereq>
       <packagereq type="default">elisa-player</packagereq>
     </packagelist>

--- a/comps.xml
+++ b/comps.xml
@@ -531,7 +531,7 @@
     <packagelist>
       <packagereq type="default">haruna</packagereq>
       <packagereq type="default">kamoso</packagereq>
-      <packagereq type="default">kalk</packagereq>
+      <packagereq type="default">kcalc</packagereq>
       <packagereq type="default">kolourpaint</packagereq>
       <packagereq type="default">plasma-browser-integration</packagereq>
       <packagereq type="default">kate</packagereq>

--- a/comps.xml
+++ b/comps.xml
@@ -13,9 +13,9 @@
     </packagelist>
   </group>
   <group>
-    <id>ultramarine-hardware-support</id>
-    <name>Ultramarine Hardware Support</name>
-    <description>Additional hardware support for Ultramarine products</description>
+    <id>ultramarine-peripheral-support</id>
+    <name>Ultramarine Peripheral Support</name>
+    <description>Additional support for various peripherals</description>
     <default>false</default>
     <uservisible>true</uservisible>
     <packagelist>
@@ -165,7 +165,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-budgie-product</groupid>
     </grouplist>
   </environment>
@@ -193,7 +193,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-budgie-product</groupid>
     </grouplist>
   </environment>
@@ -332,7 +332,7 @@
       <!-- <groupid>input-methods</groupid> While the other groups incluide this, Fedora doesn't have this group in the workstation comp, going to trust them-->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-gnome-product</groupid>
     </grouplist>
   </environment>
@@ -389,7 +389,7 @@
       <!-- We should use fcitx5 in plasma instead -->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-plasma-product</groupid>
     </grouplist>
   </environment>
@@ -419,7 +419,7 @@
       <!-- We should use fcitx5 in plasma instead -->
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-plasma-product</groupid>
     </grouplist>
   </environment>
@@ -485,7 +485,7 @@
       <groupid>input-methods</groupid>
       <groupid>ultramarine-product-common</groupid>
       <groupid>ultramarine-desktop-product-common</groupid>
-      <groupid>ultramarine-hardware-support</groupid>
+      <groupid>ultramarine-peripheral-support</groupid>
       <groupid>ultramarine-xfce-product</groupid>
     </grouplist>
   </environment>

--- a/comps.xml
+++ b/comps.xml
@@ -19,7 +19,7 @@
     <default>false</default>
     <uservisible>true</uservisible>
     <packagelist>
-      <packagereq type="default">udev-joystick-blacklist</packagereq>
+      <packagereq type="default">udev-joystick-blacklist-rm</packagereq>
       <packagereq type="default">android-udev-rules</packagereq>
       <packagereq type="default">8bitdo-udev-rules</packagereq>
     </packagelist>


### PR DESCRIPTION
We should be replacing default apps with better, more modern alternatives, and we're gonna be doing that here in this PR

## General

- Added general Ultramarine Hardware Support group for additional HWE configs (udev rules, etc)

## Plasma

- Gwenview -> Koko (Image Viewer)
- KWrite -> Kate (Text Editor)

Rationale for removing KWrite as a default application is to avoid user confusion, as Kate already works well as a basic text editor, with optional LSP and project support. It is also actually more lightweight than KWrite.