### PR TITLE
[um43] chore(gpg-keys): Only build on x86_64 (#291)

### DIFF
--- a/ultramarine/gpg-keys/anda.hcl
+++ b/ultramarine/gpg-keys/anda.hcl
@@ -1,4 +1,5 @@
 project "pkg" {
+    arches = ["x86_64"]
     rpm {
         spec = "ultramarine-gpg-keys.spec"
         sources =  "."


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [chore(gpg-keys): Only build on x86_64 (#291)](https://github.com/Ultramarine-Linux/packages/pull/291)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)