### PR TITLE
fix(comps): add lm_sensors to plasma

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -56,6 +56,7 @@
       <packagereq type="default">linux-firmware</packagereq>
       <packagereq type="default">NetworkManager-tui</packagereq>
       <packagereq type="default">zstd</packagereq>
+      <packagereq type="default">lm_sensors</packagereq>
     </packagelist>
   </group>
   <group>
@@ -344,7 +345,6 @@
       <!-- <packagereq type="default">haruna</packagereq> flatpak'd -->
       <!-- <packagereq type="default">kcalc</packagereq> flatpak'd -->
       <packagereq type="default">krdp</packagereq>
-      <packagereq type="default">lm_sensors</packagereq>
     </packagelist>
   </group>
   <environment>

--- a/comps.xml
+++ b/comps.xml
@@ -344,6 +344,7 @@
       <!-- <packagereq type="default">haruna</packagereq> flatpak'd -->
       <!-- <packagereq type="default">kcalc</packagereq> flatpak'd -->
       <packagereq type="default">krdp</packagereq>
+      <packagereq type="default">lm_sensors</packagereq>
     </packagelist>
   </group>
   <environment>


### PR DESCRIPTION
seems to be an optional dependency of kdiscover

close https://github.com/Ultramarine-Linux/triage/issues/101