### PR TITLE
[um44] feat: Mock GPG keys (#298)

### DIFF
--- a/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
+++ b/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
@@ -29,6 +29,12 @@ BuildArch:      noarch
 %description
 GPG keys for Ultramarine Linux, used for verifying RPM package signatures.
 
+%package -n     ultramarine-mock-gpg-keys
+Summary:        Ultramarine GPG keys for Mock
+
+%description -n ultramarine-mock-gpg-keys
+Ultramarine GPG key copies for use in Mock.
+
 %prep
 
 %build
@@ -37,6 +43,13 @@ GPG keys for Ultramarine Linux, used for verifying RPM package signatures.
 install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/rpm-gpg/
 
+install -d -m 755 $RPM_BUILD_ROOT/etc/pki/mock
+install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/mock/
+
 %files
 %dir /etc/pki/rpm-gpg
 /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+
+%files -n ultramarine-mock-gpg-keys
+%dir /etc/pki/mock
+/etc/pki/mock/RPM-GPG-KEY-*

--- a/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
+++ b/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           ultramarine-mock-configs
 Version:        1.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Mock configs for `ultramarine-linux`
 
 License:        MIT
@@ -19,6 +19,7 @@ Source10:       ultramarine-44-x86_64.cfg
 Source11:       ultramarine-44-aarch64.cfg
 Source12:       ultramarine-rawhide-x86_64.cfg
 Source13:       ultramarine-rawhide-aarch64.cfg
+Requires:       ultramarine-mock-gpg-keys
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [feat: Mock GPG keys (#298)](https://github.com/Ultramarine-Linux/packages/pull/298)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)