### PR TITLE
[um42] feat: Mock GPG keys (#298)

### DIFF
--- a/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
+++ b/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
@@ -29,6 +29,12 @@ BuildArch:      noarch
 %description
 GPG keys for Ultramarine Linux, used for verifying RPM package signatures.
 
+%package -n     ultramarine-mock-gpg-keys
+Summary:        Ultramarine GPG keys for Mock
+
+%description -n ultramarine-mock-gpg-keys
+Ultramarine GPG key copies for use in Mock.
+
 %prep
 
 %build
@@ -37,6 +43,13 @@ GPG keys for Ultramarine Linux, used for verifying RPM package signatures.
 install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/rpm-gpg/
 
+install -d -m 755 $RPM_BUILD_ROOT/etc/pki/mock
+install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/mock/
+
 %files
 %dir /etc/pki/rpm-gpg
 /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+
+%files -n ultramarine-mock-gpg-keys
+%dir /etc/pki/mock
+/etc/pki/mock/RPM-GPG-KEY-*

--- a/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
+++ b/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
@@ -1,26 +1,25 @@
 Name:           ultramarine-mock-configs
-Version:        1.2
-Release:        5%{?dist}
-Summary:        Mock configs for`ultramarine-linux`
+Version:        1.3
+Release:        3%{?dist}
+Summary:        Mock configs for `ultramarine-linux`
 
 License:        MIT
 URL:            https://ultramarine-linux.org
-Source0:        ultramarine-35-x86_64.cfg
-Source2:        ultramarine.tpl
-Source3:        ultramarine-testing.tpl
-Source4:        ultramarine-36-x86_64.cfg
-Source5:        ultramarine-37-x86_64.cfg
-Source6:        ultramarine-37-aarch64.cfg
-Source7:        ultramarine-38-x86_64.cfg
-Source8:        ultramarine-38-aarch64.cfg
-Source9:        ultramarine-39-x86_64.cfg
-Source10:       ultramarine-39-aarch64.cfg
-Source11:       ultramarine-40-x86_64.cfg
-Source12:       ultramarine-40-aarch64.cfg
-Source13:       ultramarine-41-x86_64.cfg
-Source14:       ultramarine-41-aarch64.cfg
-Source15:       ultramarine-42-x86_64.cfg
-Source16:       ultramarine-42-aarch64.cfg
+Source0:        ultramarine.tpl
+Source1:        ultramarine-rawhide.tpl
+Source2:        ultramarine-40-x86_64.cfg
+Source3:        ultramarine-40-aarch64.cfg
+Source4:        ultramarine-41-x86_64.cfg
+Source5:        ultramarine-41-aarch64.cfg
+Source6:        ultramarine-42-x86_64.cfg
+Source7:        ultramarine-42-aarch64.cfg
+Source8:        ultramarine-43-x86_64.cfg
+Source9:        ultramarine-43-aarch64.cfg
+Source10:       ultramarine-44-x86_64.cfg
+Source11:       ultramarine-44-aarch64.cfg
+Source12:       ultramarine-rawhide-x86_64.cfg
+Source13:       ultramarine-rawhide-aarch64.cfg
+Requires:       ultramarine-mock-gpg-keys
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um42`:
 - [feat: Mock GPG keys (#298)](https://github.com/Ultramarine-Linux/packages/pull/298)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)