### PR TITLE
Add Home/End keybindings to zsh config

### DIFF
--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -1,6 +1,6 @@
 Name:           ultramarine-shell-config
 Version:        %{?fedora}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Shell configuration for Ultramarine Linux
 License:        MIT
 

--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -21,7 +21,7 @@ bindkey "^[[3~" delete-char
 bindkey -M emacs '^[[3;3~' kill-word
 
 # Home/End Keybinds
-bindkey '^[[H' beginning-of line
+bindkey '^[[H' beginning-of-line
 bindkey '^[[F' end-of-line
 
 HISTFILE=~/.zsh_history

--- a/ultramarine/shell-config/ultramarine-shell.zsh
+++ b/ultramarine/shell-config/ultramarine-shell.zsh
@@ -20,6 +20,10 @@ bindkey '^[[3;5~' kill-word
 bindkey "^[[3~" delete-char
 bindkey -M emacs '^[[3;3~' kill-word
 
+# Home/End Keybinds
+bindkey '^[[H' beginning-of line
+bindkey '^[[F' end-of-line
+
 HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000


### PR DESCRIPTION
Add keybindings to default zsh config so Home/End keys go to the beginning/end of the line.