### PR TITLE
[um42] chore(ci): Port missing workflows (#314)

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,0 +1,58 @@
+name: Update per branch
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  autoupdate:
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        branch:
+          - umrawhide
+          - um44
+          - um43
+          - um42
+    container:
+      image: ghcr.io/terrapkg/builder:frawhide
+      options: --cap-add=SYS_ADMIN --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+          ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}
+
+      - name: Install SSH signing key & Set up git repository
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+          chmod 0700 ${{ runner.temp }}/signing_key
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Run Update
+        run: |
+          nbranch="${{ matrix.branch }}"
+          [ "$nbranch" = 'umrawhide' ] && nbranch='um42'
+          anda update --filters updbranch=1 --labels branch=${{ matrix.branch }},nbranch=$nbranch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_BACKTRACE: full
+
+      - name: Save
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config user.name "Raboneko"
+            git config user.email "raboneko@fyralabs.com"
+            git config gpg.format "ssh"
+            git config user.signingkey "${{ runner.temp }}/signing_key"
+            msg="bump(branch): $(anda run andax/ci/update_commit_message.rhai)"
+            git commit -S -a -m "$msg"
+            git push -u origin --all
+          fi

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -1,8 +1,13 @@
 name: Push comps updates
+permissions:
+  contents: read
 
 on:
   push:
     branches:
+      - umrawhide
+      - um44
+      - um43
       - um42
     paths:
       - comps.xml
@@ -10,11 +15,11 @@ on:
 
 jobs:
   update-comps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/terrapkg/builder:f42
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Push to subatomic
         run: |
           branch=${{ github.ref_name }}

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -1,0 +1,57 @@
+name: Nightly Update
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  autoupdate:
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/terrapkg/builder:frawhide
+      options: --cap-add=SYS_ADMIN --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}
+
+      - name: Install SSH signing key & Set up git repository
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+          chmod 0700 ${{ runner.temp }}/signing_key
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Run Nightly Update
+        run: anda update --filters nightly=1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_BACKTRACE: full
+
+      - name: Save
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config user.name "Raboneko"
+            git config user.email "raboneko@fyralabs.com"
+            git config gpg.format "ssh"
+            git config user.signingkey "${{ runner.temp }}/signing_key"
+            msg="bump(nightly): $(anda run andax/ci/update_commit_message.rhai)"
+            git commit -S -a -m "$msg"
+            git format-patch HEAD^
+            copy_over () {
+              git checkout $1
+              git apply *.patch || true
+              git add anda
+              git commit -S -a -m "$msg"
+            }
+            copy_over um44 || true
+            copy_over um43 || true
+            copy_over um42 || true
+            git push -u origin --all
+          fi

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -1,0 +1,57 @@
+name: Weekly Update
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  autoupdate:
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/terrapkg/builder:frawhide
+      options: --cap-add=SYS_ADMIN --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}
+
+      - name: Install SSH signing key & Set up git repository
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+          chmod 0700 ${{ runner.temp }}/signing_key
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Run Weekly Update
+        run: anda update --filters weekly=$(date "+%w")
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_BACKTRACE: full
+
+      - name: Save
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config user.name "Raboneko"
+            git config user.email "raboneko@fyralabs.com"
+            git config gpg.format "ssh"
+            git config user.signingkey "${{ runner.temp }}/signing_key"
+            msg="bump(weekly): $(anda run andax/ci/update_commit_message.rhai)"
+            git commit -S -a -m "$msg"
+            git format-patch HEAD^
+            copy_over () {
+              git checkout $1
+              git apply *.patch || true
+              git add anda
+              git commit -S -a -m "$msg"
+            }
+            copy_over um44 || true
+            copy_over um43 || true
+            copy_over um42 || true
+            git push -u origin --all
+          fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um42`:
 - [chore(ci): Port missing workflows (#314)](https://github.com/Ultramarine-Linux/packages/pull/314)

<!--- Backport version: 11.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)