### PR TITLE
[43]: chore: cleanup some packages and comps (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ultramarine Linux packages monorepo
 
-This repository is a monorepo containing all the distribution packages for Ultramarine Linux.
+This repository is a monorepo containing all packages specifically for Ultramarine Linux.
 
 This repository uses the [Andaman](https://github.com/FyraLabs/anda) toolchain to manage its packages, created by Fyra Labs (the company behind Ultramarine Linux).
 
@@ -27,8 +27,6 @@ cargo install anda
 ```
 
 Once Andaman is installed, you can clone this repository and build the packages.
-
-To list all current packages in this repository, you can use the `list` command.
 
 ```bash
 anda list

--- a/comps.xml
+++ b/comps.xml
@@ -46,6 +46,11 @@
       <packagereq type="default">ultramarine-system-configs-core</packagereq>
       <packagereq type="default">ultramarine-repos</packagereq>
       <packagereq type="default">git</packagereq>
+      <packagereq type="default">vim</packagereq>
+      <packagereq type="default">nano</packagereq>
+      <packagereq type="default">htop</packagereq>
+      <packagereq type="default">rsync</packagereq>
+      <packagereq type="default">dive</packagereq>
       <packagereq type="default">umcli</packagereq>
       <packagereq type="default">fastfetch</packagereq>
       <packagereq type="default">linux-firmware</packagereq>

--- a/ultramarine/backgrounds/ultramarine-backgrounds.spec
+++ b/ultramarine/backgrounds/ultramarine-backgrounds.spec
@@ -1,9 +1,9 @@
-%define ver 43
 %undefine _disable_source_fetch
 
 Name: ultramarine-backgrounds
-Version: %(echo %ver | sed 's/-/~/g')
-Release: 2%{?dist}
+# This version tracks the upstream version tag. Do not bump this when branching a new release unless the upstream release matches.
+Version: 43
+Release: 1%{?dist}
 BuildArch: noarch
 # details for the artworks' licenses can be seen in the COPYING file
 License: CC-BY-SA 4.0 and CC0
@@ -12,10 +12,9 @@ Provides: desktop-backgrounds = %{version}-%{release}
 Recommends: ultramarine-backgrounds-compat = %{version}-%{release}
 BuildRequires: make ImageMagick
 # licensing information
-Source0: https://github.com/Ultramarine-Linux/backgrounds/archive/refs/tags/%ver.tar.gz
+Source0: https://github.com/Ultramarine-Linux/backgrounds/archive/refs/tags/%version.tar.gz
 #Source1: 30_default_backgrounds.gschema.override
 # CC0 artworks
-
 
 %description
 This package contains desktop backgrounds for the Ultramarine Linux default theme.
@@ -43,7 +42,7 @@ The desktop-backgrounds-gnome package sets default background in GNOME-based des
 
 %package        kde
 Summary:        The default KDE wallpaper from KDE desktop
-Requires:   ultramarine-backgrounds-common = %{version}-%{release}
+Requires:       ultramarine-backgrounds-common = %{version}-%{release}
 Provides:       system-backgrounds-kde = %{version}-%{release}
 License:        CC0
 
@@ -61,7 +60,7 @@ License:        CC0
 The desktop-backgrounds-compat package contains compatibility symlinks for other desktop environments.
 
 %prep
-%autosetup -n backgrounds-%{ver}
+%autosetup -n backgrounds-%{version}
 
 
 %install
@@ -168,12 +167,12 @@ ln -rsf "%{buildroot}%{_datadir}/backgrounds/images/default-dark.jxl" "%{buildro
 %files common
 %{_datadir}/backgrounds/ultramarine-linux/
 %{_datadir}/glib-2.0/schemas/30_default_backgrounds.gschema.override
-/usr/share/wallpapers/Ultramarine*/metadata.json
+%{_datadir}/wallpapers/Ultramarine*/metadata.json
 
 %files gnome
 %{_datadir}/gnome-background-properties/ultramarine-wallpapers-extras.xml
 %{_datadir}/gnome-background-properties/ultramarine.xml
-%exclude /usr/share/gnome-background-properties/41-community-extras.xml
+%exclude %{_datadir}/gnome-background-properties/41-community-extras.xml
 
 %files kde
 %{_datadir}/wallpapers/*

--- a/ultramarine/backgrounds/ultramarine-backgrounds.spec
+++ b/ultramarine/backgrounds/ultramarine-backgrounds.spec
@@ -3,7 +3,7 @@
 Name: ultramarine-backgrounds
 # This version tracks the upstream version tag. Do not bump this when branching a new release unless the upstream release matches.
 Version: 43
-Release: 1%{?dist}
+Release: 2%{?dist}
 BuildArch: noarch
 # details for the artworks' licenses can be seen in the COPYING file
 License: CC-BY-SA 4.0 and CC0

--- a/ultramarine/backgrounds/update.rhai
+++ b/ultramarine/backgrounds/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Ultramarine-Linux/backgrounds"));

--- a/ultramarine/budgie-filesystem/ultramarine-budgie-filesystem.spec
+++ b/ultramarine/budgie-filesystem/ultramarine-budgie-filesystem.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-budgie-filesystem
-Version:        43
+Version:        %{?fedora}
 Release:        1%{?dist}
 Summary:        Assets for Ultramarine Linux Budgie
 

--- a/ultramarine/fun/ultramarine-fun.spec
+++ b/ultramarine/fun/ultramarine-fun.spec
@@ -1,7 +1,5 @@
-%define debug_package %nil
-
 Name:			ultramarine-fun
-Version:		43
+Version:		%{?fedora}
 Release:		1%?dist
 Summary:		Additional secret/hidden files for ultramarine Linux
 License:		MIT

--- a/ultramarine/hop/ultramarine-hop.spec
+++ b/ultramarine/hop/ultramarine-hop.spec
@@ -1,8 +1,8 @@
 Name:           ultramarine-hop
 Version:        0.1.5
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Hop between desktop environments and editions easily!
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 URL:            https://github.com/Ultramarine-Linux/hop
 Requires:       dnf5
 Requires:       ultramarine-release

--- a/ultramarine/kde-settings/kde-settings.spec
+++ b/ultramarine/kde-settings/kde-settings.spec
@@ -1,14 +1,10 @@
-%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
 %bcond initialsetup_gui_backend 1
-%else
-%bcond initialsetup_gui_backend 0
-%endif
 
 Summary: Config files for KDE
 Name:    kde-settings
 Epoch:   1
-Version: 43
-Release: 2%{?dist}
+Version: %{?fedora}
+Release: 1%{?dist}
 
 License: MIT
 Url:     https://github.com/Ultramarine-Linux/kde-settings

--- a/ultramarine/langpacks/ultramarine-langpacks.spec
+++ b/ultramarine/langpacks/ultramarine-langpacks.spec
@@ -1,7 +1,7 @@
 # ? https://src.fedoraproject.org/rpms/langpacks/tree/rawhide
 
 Name:      ultramarine-langpacks
-Version:   43
+Version:   %{?fedora}
 Release:   1%{?dist}
 Summary:   Langpacks meta-package
 

--- a/ultramarine/logos/ultramarine-logos.spec
+++ b/ultramarine/logos/ultramarine-logos.spec
@@ -1,7 +1,7 @@
 Name:          ultramarine-logos
 %define        _alt_name fedora-logos
 Summary:       Icons and pictures related to Ultramarine Linux
-Version:       43
+Version:       %{?fedora}
 %define        _release 1%{?dist}
 Release:       1%{?dist}
 URL:           https://github.com/Ultramarine-Linux/logos
@@ -14,7 +14,7 @@ Provides:      system-logos = %{version}-%{_release}
 Provides:      %{_alt_name} = %{version}-%{_release}
 BuildArch:     noarch
 BuildRequires: hardlink
-Requires:      ultramarine-release = 43
+Requires:      ultramarine-release = %{version}
 
 %if ! 0%{?eln}
 # For _kde4_* macros:

--- a/ultramarine/pipewire-systemd-mask/pipewire-systemd-mask.spec
+++ b/ultramarine/pipewire-systemd-mask/pipewire-systemd-mask.spec
@@ -1,5 +1,5 @@
 Name:			pipewire-systemd-mask
-Version:		43
+Version:		%{?fedora}
 Release:		1%?dist
 Summary:		Mask pipewire.service and pipewire.socket
 License:		MIT

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -3,7 +3,7 @@
 %global release_name Gas Meter
 %global fedora_codename Forty Three
 %global codename gas_meter
-%define dist_version 43
+%define dist_version %{?fedora}
 
 %define xfce_conf_commit 4ee924020b97cf2b4d30510641a2f63ef06ed148
 

--- a/ultramarine/repos/repos.spec
+++ b/ultramarine/repos/repos.spec
@@ -1,8 +1,8 @@
-%global _dist_version 43
+%global _dist_version %{?fedora}
 
 Name: ultramarine-repos
 Version: %{_dist_version}
-Release: 4%{?dist}
+Release: 3%{?dist}
 License: MIT
 Summary: Repositories for Ultramarine Linux
 Requires: %{name}-common = %{version}-%{release}
@@ -12,7 +12,7 @@ Provides: ultramarine-repos(%{_dist_version}) = %{_dist_version}
 BuildArch: noarch
 
 %description
-Metapackage for Ultramarine Linux repositories
+Metapackage for Ultramarine Linux repositories.
 
 %package common
 Summary: Common repository for Ultramarine Linux
@@ -21,6 +21,7 @@ Requires: ultramarine-gpg-keys
 Source100: ultramarine.repo
 # UM40 patch
 Requires: terra-release
+Requires: terra-release-mesa
 # todo: if upgrading from 39 require terra-release or something
 %description common
 Common repository files for Ultramarine Linux
@@ -30,7 +31,6 @@ Summary: Additional repositories for Ultramarine Linux
 Requires: distribution-gpg-keys
 Requires: flatpak
 Requires: terra-release-extras
-Requires: terra-release-mesa
 Source200: https://flathub.org/repo/flathub.flatpakrepo
 
 # Don't own the rpmfusion repositories, let it be overridden by the real packages
@@ -45,6 +45,7 @@ Additional repository files for Ultramarine Linux that provides access to popula
     - RPMFusion Free (all patented codecs filtered out)
     - RPMFusion Nonfree (enabled by default)
     - Repositories for secureboot support for 'akmod' kernel modules (enabled by default)
+    - Terra Extras repo (packages that conflict with Fedora)
 
 
 %package appcenter
@@ -53,7 +54,7 @@ Requires: %{name}-extras = %{version}-%{release}
 Source201: https://flatpak.elementary.io/repo.flatpakrepo
 
 %description appcenter
-AppCenter repository file for Ultramarine Linux
+%{summary}.
 
 %package rpi
 Summary: Additional repo for Raspberry Pi Kernel
@@ -89,9 +90,11 @@ cp -avx %{SOURCE300} %{buildroot}/%{_sysconfdir}/yum.repos.d/
 %{_sysconfdir}/flatpak/remotes.d/flathub.flatpakrepo
 %files appcenter
 %{_sysconfdir}/flatpak/remotes.d/appcenter.flatpakrepo
-#%%{_sysconfdir}/yum.repos.d/rpmfusion-free.repo
-#%%{_sysconfdir}/yum.repos.d/rpmfusion-free-updates.repo
-#%%{_sysconfdir}/yum.repos.d/rpmfusion-nonfree.repo
-#%%{_sysconfdir}/yum.repos.d/rpmfusion-nonfree-updates.repo
 %files rpi
 %{_sysconfdir}/yum.repos.d/dwrobel-kernel-rpi-fedora-%{version}.repo
+%dnl %{_sysconfdir}/yum.repos.d/rpmfusion-free.repo
+%dnl %{_sysconfdir}/yum.repos.d/rpmfusion-free-updates.repo
+%dnl %{_sysconfdir}/yum.repos.d/rpmfusion-nonfree.repo
+%dnl %{_sysconfdir}/yum.repos.d/rpmfusion-nonfree-updates.repo
+%dnl %files rpi
+%dnl %{_sysconfdir}/yum.repos.d/dwrobel-kernel-rpi-fedora-%{version}.repo

--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -1,7 +1,6 @@
-
 Name:           ultramarine-shell-config
-Version:        43
-Release:        6%{?dist}
+Version:        %{?fedora}
+Release:        1%{?dist}
 Summary:        Shell configuration for Ultramarine Linux
 License:        MIT
 
@@ -17,8 +16,8 @@ Requires:       bat
 Requires:       starship
 Requires:       fzf
 
-
 BuildArch:      noarch
+
 %description
 This package contains shell configurations made for Ultramarine Linux.
 
@@ -58,7 +57,6 @@ fi
 %{_sysconfdir}/profile.d/ultramarine-shell.sh
 
 %changelog
-
 * Sun Oct 19 2025 Jaiden Riordan <jade@fyralabs.com> - 43-1
 - Copy rewrite
 

--- a/ultramarine/ultramarine-appstream-metadata/ultramarine-appstream-metadata.spec
+++ b/ultramarine/ultramarine-appstream-metadata/ultramarine-appstream-metadata.spec
@@ -2,29 +2,25 @@ Summary:        Operating System AppStream Metadata for Ultramarine Linux
 Name:           ultramarine-appstream-metadata
 # Use the time of the last metadata update as version
 Version:        20251125
-Release:        %autorelease
+Release:        2%?dist
 License:        MIT
 URL:            https://ultramarine-linux.org/
 Source0:        https://github.com/Ultramarine-Linux/ultramarine-appstream-metadata/archive/refs/tags/%version.tar.gz
 BuildArch:      noarch
 
 %description
-Operating System AppStream Metadata for Ultramarine Linux
+%{summary}.
 
 %prep
 %autosetup
-# only appstream 1.0 knows about "snapshot" releases
-%if 0%{?fedora} < 40
-sed -i '/<release / s/type="snapshot"/type="development"/' org.ultramarine-linux.ultramarine.metainfo.xml
-%endif
 
 %build
 
 %install
-install -Dpm 0644 org.ultramarine-linux.ultramarine.metainfo.xml %{buildroot}%{_datadir}/metainfo/org.ultramarine-linux.ultramarine.metainfo.xml
+install -Dpm 0644 org.ultramarine-linux.ultramarine.metainfo.xml %{buildroot}%{_metainfodir}/org.ultramarine-linux.ultramarine.metainfo.xml
 
 %files
-%{_datadir}/metainfo/org.ultramarine-linux.ultramarine.metainfo.xml
+%{_metainfodir}/org.ultramarine-linux.ultramarine.metainfo.xml
 
 %changelog
 %autochangelog

--- a/ultramarine/ultramarine-raw-filesystem/ultramarine-raw-filesystem.spec
+++ b/ultramarine/ultramarine-raw-filesystem/ultramarine-raw-filesystem.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-raw-filesystem
-Version:        43
+Version:        %{?fedora}
 Release:        1%{?dist}
 Summary:        systemd-repart config to automatically extend the root filesystem on raw images
 URL:            ultramarine-linux.org

--- a/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
+++ b/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-system-configs
-Version:        43
+Version:        %{?fedora}
 Release:        1%{?dist}
 Summary:        Various configuration files for a more comfortable Ultramarine desktop experience
 BuildArch:      noarch

--- a/ultramarine/ultramarine-wsl-filesystem/ultramarine-wsl-filesystem.spec
+++ b/ultramarine/ultramarine-wsl-filesystem/ultramarine-wsl-filesystem.spec
@@ -4,8 +4,8 @@
 # - https://salsa.debian.org/debian/WSL
 
 Name:           ultramarine-wsl-filesystem
-Version:        43
-Release:        3%{?dist}
+Version:        %{?fedora}
+Release:        1%{?dist}
 Summary:        Ultramarine for WSL configuration files
 URL:            ultramarine-linux.org
 

--- a/ultramarine/umcli/umcli.spec
+++ b/ultramarine/umcli/umcli.spec
@@ -21,14 +21,13 @@ Requires:	ansible-collection-ansible-posix
 
 Obsoletes: golang-github-ultramarine-linux-um <= 0.4.5
 
-
 %description
 %summary.
 
 %gopkg
 
 %prep
-%autosetup -n um-%version -p1
+%autosetup -n um-%version
 go mod download
 
 %build
@@ -48,9 +47,6 @@ cp -av data/. %{buildroot}%{_datadir}/um/.
 %doc README.md
 %{_bindir}/um
 %{_datadir}/um/
-
-%dnl %gopkgfiles
-
 
 %changelog
 * Sun January 18 2026 Jaiden Riordan <jade@fyralabs.com> - 0.4.5-2


### PR DESCRIPTION
* chore: cleanup some packages and comps

- Add packages currently in Ultramarine build scripts into the product-common comp, as to not repeat these packages in multiple build scripts (WSL)
- Fix some formatting and use proper macros for some packages
- Remove some outdated scripts (for older Fedora versions)
- Move terra-release-mesa dep from ultramarine-repos-extras to ultramarine-repos-common, and update description of ultramarine-repos-extras to add terra-release-extras



* feat: use %{?fedora}



* chore: remove outdated if statement in kde-settings



* feat (backgrounds): use repos version, add update.rhai



* doc: update README



* Add backgrounds comment

---------