### PR TITLE
[um43] chore(ci): Port Terra security changes (#315)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,6 +1,8 @@
 # for each folder in ultramarine/
 # generate a new workflow for each folder in ultramarine/
 name: Automatically build packages
+permissions:
+  contents: read
 on:
   push:
     paths:
@@ -44,7 +46,7 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up git repository
@@ -52,7 +54,7 @@ jobs:
 
       - name: Cache buildroot
         id: br-cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: /var/cache
           key: ${{ runner.os }}-br-${{ matrix.version }}-${{ matrix.pkg.arch }}
@@ -71,7 +73,7 @@ jobs:
           x=${NAME//\//@}
           echo "name=$x" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ steps.art.outputs.name }}
           path: |

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,4 +1,6 @@
 name: Bootstrap
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 
@@ -15,7 +17,7 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build ultramarine-mock-configs
         run: |

--- a/.github/workflows/mass-rebuild.yml
+++ b/.github/workflows/mass-rebuild.yml
@@ -1,6 +1,8 @@
 # for each folder in ultramarine/
 # generate a new workflow for each folder in ultramarine/
 name: Mass Rebuild
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   workflow_call:
@@ -18,7 +20,7 @@ jobs:
     # check out the repo
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -50,7 +52,7 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up git repository
@@ -70,7 +72,7 @@ jobs:
           x=${NAME//\//@}
           echo "name=$x" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ steps.art.outputs.name }}
           path: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,41 @@
+name: Automatic backport/sync action
+permissions:
+  contents: read
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Backport/sync PR
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.merged
+    steps:
+      - name: Install SSH signing key
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+          chmod 0700 ${{ runner.temp }}/signing_key
+
+      - name: Setup Raboneko Signing
+        run: |
+          git config --global gpg.format "ssh"
+          git config --global user.signingkey "${{ runner.temp }}/signing_key"
+          git config --global commit.gpgsign true
+
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@9460b7102fea25466026ce806c9ebf873ac48721 # v11.0.0
+        with:
+          github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
+          auto_backport_label_prefix: sync-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [chore(ci): Port Terra security changes (#315)](https://github.com/Ultramarine-Linux/packages/pull/315)

<!--- Backport version: 11.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)