### PR TITLE
[um44] chore(ci): I missed a checkout action (#326)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set workspace as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Generate build matrix


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [chore(ci): I missed a checkout action (#326)](https://github.com/Ultramarine-Linux/packages/pull/326)

<!--- Backport version: 11.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)