### PR TITLE
[um44] fix(comps): add lm_sensors to plasma (#297)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -56,6 +56,7 @@
       <packagereq type="default">linux-firmware</packagereq>
       <packagereq type="default">NetworkManager-tui</packagereq>
       <packagereq type="default">zstd</packagereq>
+      <packagereq type="default">lm_sensors</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [fix(comps): add lm_sensors to plasma (#297)](https://github.com/Ultramarine-Linux/packages/pull/297)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)