### PR TITLE
[um44]  fix: set firewalld-workstation symlink (#299)

### DIFF
--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -1070,6 +1070,11 @@ install -Dm0644 %{SOURCE32} -t %{buildroot}%{_datadir}/polkit-1/rules.d/
 %endif
 
 
+%post desktop
+mkdir -p %{_sysconfdir}/firewalld
+ln -sf firewalld-workstation.conf %{_sysconfdir}/firewalld/firewalld.conf
+
+
 %files common
 %_datadir/dnf5/libdnf.conf.d/ultramarine-installonly-2.conf
 %{_datadir}/dnf/plugins/copr.vendor.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [ fix: set firewalld-workstation symlink (#299)](https://github.com/Ultramarine-Linux/packages/pull/299)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)