### PR TITLE
[um43] fix licenses on backgrounds (#338)

### DIFF
--- a/ultramarine/backgrounds/ultramarine-backgrounds.spec
+++ b/ultramarine/backgrounds/ultramarine-backgrounds.spec
@@ -6,7 +6,7 @@ Version: 43
 Release: 2%{?dist}
 BuildArch: noarch
 # details for the artworks' licenses can be seen in the COPYING file
-License: CC-BY-SA 4.0 and CC0
+License: CC-BY-SA-4.0 AND CC0-1.0
 Summary: Ultramarine Linux backgrounds
 Provides: desktop-backgrounds = %{version}-%{release}
 Recommends: ultramarine-backgrounds-compat = %{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [fix licenses on backgrounds (#338)](https://github.com/Ultramarine-Linux/packages/pull/338)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)