### PR TITLE
[um44] chore: Update Mock configs for being in a separate repo (#272)

### DIFF
--- a/ultramarine/ultramarine-mock-configs/anda.hcl
+++ b/ultramarine/ultramarine-mock-configs/anda.hcl
@@ -1,4 +1,5 @@
 project "pkg" {
+    arches = ["x86_64"]
     rpm {
         spec = "ultramarine-mock-configs.spec"
         sources = "."

--- a/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
+++ b/ultramarine/ultramarine-mock-configs/ultramarine-mock-configs.spec
@@ -1,53 +1,28 @@
 Name:           ultramarine-mock-configs
 Version:        1.3
-Release:        3%{?dist}
-Summary:        Mock configs for `ultramarine-linux`
+Release:        1%{?dist}
+Summary:        Mock configs for Ultramarine Linux
 
 License:        MIT
 URL:            https://ultramarine-linux.org
-Source0:        ultramarine.tpl
-Source1:        ultramarine-rawhide.tpl
-Source2:        ultramarine-40-x86_64.cfg
-Source3:        ultramarine-40-aarch64.cfg
-Source4:        ultramarine-41-x86_64.cfg
-Source5:        ultramarine-41-aarch64.cfg
-Source6:        ultramarine-42-x86_64.cfg
-Source7:        ultramarine-42-aarch64.cfg
-Source8:        ultramarine-43-x86_64.cfg
-Source9:        ultramarine-43-aarch64.cfg
-Source10:       ultramarine-44-x86_64.cfg
-Source11:       ultramarine-44-aarch64.cfg
-Source12:       ultramarine-rawhide-x86_64.cfg
-Source13:       ultramarine-rawhide-aarch64.cfg
-Requires:       ultramarine-mock-gpg-keys
+Source0:        https://github.com/Ultramarine-Linux/mock-configs/archive/refs/tags/v%{version}.tar.gz
 BuildArch:      noarch
 
 %description
 %{summary}.
 
 %prep
+%autosetup -n mock-configs-%{version}
 
 %build
 
 %install
 mkdir -p %{buildroot}/etc/mock/templates
-cp -v %{SOURCE0} %{buildroot}/etc/mock/templates
-cp -v %{SOURCE1} %{buildroot}/etc/mock/templates
-cp -v %{SOURCE2} %{buildroot}/etc/mock/
-cp -v %{SOURCE3} %{buildroot}/etc/mock/
-cp -v %{SOURCE4} %{buildroot}/etc/mock/
-cp -v %{SOURCE5} %{buildroot}/etc/mock/
-cp -v %{SOURCE6} %{buildroot}/etc/mock/
-cp -v %{SOURCE7} %{buildroot}/etc/mock/
-cp -v %{SOURCE8} %{buildroot}/etc/mock/
-cp -v %{SOURCE9} %{buildroot}/etc/mock/
-cp -v %{SOURCE10} %{buildroot}/etc/mock/
-cp -v %{SOURCE11} %{buildroot}/etc/mock/
-cp -v %{SOURCE12} %{buildroot}/etc/mock/
-cp -v %{SOURCE13} %{buildroot}/etc/mock/
+cp -v ./*.tpl -t %{buildroot}/etc/mock/templates
+cp -v ./*.cfg -t %{buildroot}/etc/mock/
 
 %files
-/etc/mock/*
+/etc/mock/*.cfg
 /etc/mock/templates/*
 
 %changelog

--- a/ultramarine/ultramarine-mock-configs/update.rhai
+++ b/ultramarine/ultramarine-mock-configs/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Ultramarine-Linux/mock-configs"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [chore: Update Mock configs for being in a separate repo (#272)](https://github.com/Ultramarine-Linux/packages/pull/272)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)