### PR TITLE
[um43] feat: Add vendor to CI (#356)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-br-${{ matrix.version }}-${{ matrix.pkg.arch }}
 
       - name: Build with Andaman
-        run: anda build -c ultramarine-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ matrix.pkg.pkg }}
+        run: anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ matrix.pkg.pkg }}
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -21,7 +21,11 @@ jobs:
 
       - name: Build ultramarine-mock-configs
         run: |
-          anda build -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/ultramarine-mock-configs/pkg -p rpm
+          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/ultramarine-mock-configs/pkg
+
+      - name: Install ultramarine-mock-configs
+        run: |
+          dnf install -y anda-build/rpm/rpms/ultramarine-mock-configs*.rpm
 
       - name: Upload packages to subatomic
         run: |

--- a/.github/workflows/mass-rebuild.yml
+++ b/.github/workflows/mass-rebuild.yml
@@ -59,7 +59,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build with Andaman
-        run: anda build -c ultramarine-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ matrix.pkg.pkg }}
+        run: anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ matrix.pkg.pkg }}
 
       - name: Generating artifact name
         id: art


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [feat: Add vendor to CI (#356)](https://github.com/Ultramarine-Linux/packages/pull/356)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)