### PR TITLE
[um44] chore: update .gitignore (#364)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 anda-build/
 .DS_Store
 .IDEA
+**/*.tar*
+**/*.crate
+**/*.zip
+**/*.minisig
+**/*.nupkg
+**/*.rpm
+**/*.kate-swp


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [chore: update .gitignore (#364)](https://github.com/Ultramarine-Linux/packages/pull/364)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)