### PR TITLE
[um42] feat(ci): Bootstrap hacks (#361)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
     container:
-      image: ghcr.io/ultramarine-linux/builder:um42
+      image: ghcr.io/terrapkg/builder:f${{ matrix.version }}
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
@@ -21,11 +21,15 @@ jobs:
 
       - name: Build ultramarine-mock-configs
         run: |
-          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/ultramarine-mock-configs/pkg
+          anda build -D "vendor Ultramarine Linux" -D "dist .um${{ matrix.version }}" -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/ultramarine-mock-configs/pkg
 
       - name: Install ultramarine-mock-configs
         run: |
           dnf install -y anda-build/rpm/rpms/ultramarine-mock-configs*.rpm
+
+      - name: Build ultramarine-release
+        run: |
+          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
 
       - name: Upload packages to subatomic
         run: |


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um42`:
 - [feat(ci): Bootstrap hacks (#361)](https://github.com/Ultramarine-Linux/packages/pull/361)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)