### PR TITLE
[um44] add fluent sddm theme (#374)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -112,6 +112,7 @@
       <packagereq type="default">ultramarine-backgrounds</packagereq>
       <packagereq type="mandatory">sddm</packagereq>
       <packagereq type="mandatory">sddm-wayland-generic</packagereq>
+      <packagereq type="mandatory">fluent-kde-theme</packagereq>
       <packagereq type="mandatory">budgie-sddm-switch</packagereq>
       <packagereq type="default">bluejay</packagereq>
       <packagereq type="default">nemo-python</packagereq>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [add fluent sddm theme (#374)](https://github.com/Ultramarine-Linux/packages/pull/374)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)