### PR TITLE
[um44] fix budgie comps (#381)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -132,7 +132,6 @@
       <packagereq type="mandatory">polkit</packagereq>
       <packagereq type="default">budgie-backgrounds</packagereq>
       <packagereq type="default">budgie-control-center</packagereq>
-      <packagereq type="default">budgie-desktop-defaults</packagereq>
       <packagereq type="default">budgie-desktop-view</packagereq>
       <packagereq type="default">glib-networking</packagereq>
       <packagereq type="default">gnome-color-manager</packagereq>
@@ -262,7 +261,6 @@
         <packagereq type="mandatory">gnome-boxes</packagereq>
         <!-- <packagereq type="mandatory">gnome-connections</packagereq> flatpak'd -->
         <packagereq type="mandatory">gnome-control-center</packagereq>
-        <packagereq type="mandatory">gnome-initial-setup</packagereq>
         <packagereq type="mandatory">gnome-session-wayland-session</packagereq>
         <packagereq type="mandatory">gnome-settings-daemon</packagereq>
         <packagereq type="mandatory">gnome-shell</packagereq>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [fix budgie comps (#381)](https://github.com/Ultramarine-Linux/packages/pull/381)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)