### PR TITLE
[um44] add: taidan-ultramarine-configs (#383)

### DIFF
--- a/ultramarine/taidan-ultramarine-configs/anda.hcl
+++ b/ultramarine/taidan-ultramarine-configs/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "taidan-ultramarine-configs.spec"
+  }
+}

--- a/ultramarine/taidan-ultramarine-configs/detect-internet
+++ b/ultramarine/taidan-ultramarine-configs/detect-internet
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+. /etc/os-release
+
+release_pkgs=$(rpm -qa 'ultramarine-release-*')
+
+has_pkg() {
+    if grep -q -- "$1" <<< "$release_pkgs"; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+is_chromebook=$(has_pkg ultramarine-release-chromebook)
+is_surface=$(has_pkg ultramarine-release-surface)
+is_rpi=$(has_pkg ultramarine-release-raspberry_pi)
+
+curl -X POST https://plausible.fyralabs.com/api/event --json @- <<EOF
+{
+    "name": "pageview",
+    "url": "app://internet/v0.2/$VERSION_ID",
+    "domain": "taidan",
+    "props": {
+        "arch": "$(arch)",
+        "edition": "$VARIANT_ID",
+        "chromebook": "$is_chromebook",
+        "surface": "$is_surface",
+        "rpi": "$is_rpi"
+    }
+}
+EOF || ping -c 1 -W 20 1.1.1.1 > /dev/null

--- a/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
+++ b/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
@@ -1,0 +1,39 @@
+Name:           taidan-ultramarine-configs
+Version:        44
+Release:        1%?dist
+Summary:        Taidan configuration for Ultramarine
+License:        (MIT AND GPL-3.0-or-later)
+Provides:       taidan-configs
+
+BuildArch:      noarch
+Source0:        detect-internet
+
+%description
+This package provides the Taidan configuration files for Ultramarine Linux.
+
+%global tweak(p:) %{quote:
+%package tweaks-%1
+Summary: Taidan tweaks: %1
+Requires: %name = %version-%release
+Supplements: taidan-ultramarine-configs
+%{?-p*}
+%description tweaks-%1
+Taidan tweaks: %1.
+%files tweaks-%1
+%_datadir/taidan/tweaks/%1
+}
+
+%tweak cachyos-kernel -p %{quote:BuildArch: x86_64_v3}
+%tweak mtu-probing
+
+%prep
+%git_clone https://github.com/Ultramarine-Linux/taidan main
+
+%install
+install -Dpm755 %{S:0} -t %buildroot%_sysconfdir/com.fyralabs.Taidan
+mkdir -p %buildroot%_datadir/taidan
+cp -r data/tweaks/ %buildroot%_datadir/taidan/
+
+%files
+%license LICENSE.md
+%config %_sysconfdir/com.fyralabs.Taidan/


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [add: taidan-ultramarine-configs (#383)](https://github.com/Ultramarine-Linux/packages/pull/383)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)