### PR TITLE
[um44] make taidan configs conflict default configs (#389)

### DIFF
--- a/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
+++ b/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
@@ -5,6 +5,7 @@ Summary:        Taidan configuration for Ultramarine
 License:        (MIT AND GPL-3.0-or-later)
 Provides:       taidan-configs
 Provides:       initial-setup initial-setup-gui
+Conflicts:      taidan-default-configs
 
 BuildArch:      noarch
 Source0:        detect-internet


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [make taidan configs conflict default configs (#389)](https://github.com/Ultramarine-Linux/packages/pull/389)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)