### PR TITLE
[um44] obsolete default configs (#394)

### DIFF
--- a/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
+++ b/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
@@ -6,6 +6,7 @@ License:        (MIT AND GPL-3.0-or-later)
 Provides:       taidan-configs
 Provides:       initial-setup initial-setup-gui
 Conflicts:      taidan-default-configs
+Obsoletes:      taidan-default-configs <= 999
 
 BuildArch:      noarch
 Source0:        detect-internet


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [obsolete default configs (#394)](https://github.com/Ultramarine-Linux/packages/pull/394)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)