### PR TITLE
[um44] umcli: dep on ansible-collection-community-general for btrfs manip (#398)

### DIFF
--- a/ultramarine/umcli/umcli.spec
+++ b/ultramarine/umcli/umcli.spec
@@ -6,7 +6,7 @@
 
 Name:           umcli
 Version:        0.4.5
-Release:        1%dist
+Release:        2%{?dist}
 Summary:        A CLI tool for managing an Ultramarine Linux system
 
 License:        GPL-3.0-or-later
@@ -18,6 +18,7 @@ BuildRequires:  pkgconfig(rpm)
 BuildRequires:  pkgconfig(flatpak)
 Requires:	ansible-core
 Requires:	ansible-collection-ansible-posix
+Requires:	ansible-collection-community-general
 
 Obsoletes: golang-github-ultramarine-linux-um <= 0.4.5
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [umcli: dep on ansible-collection-community-general for btrfs manip (#398)](https://github.com/Ultramarine-Linux/packages/pull/398)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)