### PR TITLE
[um44] MATERIA THEME BECAUSE BREEZE DEPS ON THE WHOLE FUCKING PLASMA STACK (#405)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -113,7 +113,7 @@
       <packagereq type="default">ultramarine-backgrounds-gnome</packagereq>
       <packagereq type="default">ultramarine-backgrounds</packagereq>
       <packagereq type="mandatory">sddm</packagereq>
-      <packagereq type="mandatory">sddm-breeze</packagereq>
+      <packagereq type="mandatory">materia-kde-sddm</packagereq>
       <packagereq type="mandatory">fluent-kde-theme</packagereq>
       <packagereq type="mandatory">budgie-sddm-switch</packagereq>
       <packagereq type="default">bluejay</packagereq>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [MATERIA THEME BECAUSE BREEZE DEPS ON THE WHOLE FUCKING PLASMA STACK (#405)](https://github.com/Ultramarine-Linux/packages/pull/405)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)