### PR TITLE
[umrawhide] chore: bump kde-settings (#410)

### DIFF
--- a/ultramarine/kde-settings/anda.hcl
+++ b/ultramarine/kde-settings/anda.hcl
@@ -1,4 +1,5 @@
 project "pkg" {
+        arches = ["x86_64"]
     rpm {
         spec = "kde-settings.spec"
         sources =  "."

--- a/ultramarine/kde-settings/kde-settings.spec
+++ b/ultramarine/kde-settings/kde-settings.spec
@@ -4,7 +4,7 @@ Summary: Config files for KDE
 Name:    kde-settings
 Epoch:   1
 Version: %{?fedora}
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 License: MIT
 Url:     https://github.com/Ultramarine-Linux/kde-settings


### PR DESCRIPTION
# Backport

This will backport the following commits from `um44` to `umrawhide`:
 - [chore: bump kde-settings (#410)](https://github.com/Ultramarine-Linux/packages/pull/410)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)