### PR TITLE
[um44] lightdm wallpapers and budgie sddm (#412)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -115,6 +115,7 @@
       <packagereq type="mandatory">sddm</packagereq>
       <packagereq type="mandatory">materia-kde-sddm</packagereq>
       <packagereq type="mandatory">fluent-kde-theme</packagereq>
+      <packagereq type="mandatory">fluent-kde-theme-sddm</packagereq>
       <packagereq type="mandatory">budgie-sddm-switch</packagereq>
       <packagereq type="default">bluejay</packagereq>
       <packagereq type="default">nemo-python</packagereq>

--- a/ultramarine/release/budgie-sddm.conf
+++ b/ultramarine/release/budgie-sddm.conf
@@ -1,2 +1,2 @@
 [Theme]
-Current=materia
+Current=fluent

--- a/ultramarine/release/slick-greeter-xfce.conf
+++ b/ultramarine/release/slick-greeter-xfce.conf
@@ -15,7 +15,7 @@
 #  xft-rgba = none|rgb|bgr|vrgb|vbgr  Type of subpixel antialiasing
 
 [Greeter]
-background=/usr/share/backgrounds/default.png
+background=/usr/share/backgrounds/default-dark.png
 #background-color=#000000
 draw-user-backgrounds=true
 draw-grid=true

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -53,7 +53,7 @@
 Summary:	Ultramarine Linux release files
 Name:		ultramarine-release
 Version:	%{dist_version}
-Release:	4%{?dist}
+Release:	5%{?dist}
 License:	MIT
 Source0:	LICENSE
 URL:        https://ultramarine-linux.org
@@ -783,7 +783,7 @@ sed -i -e "s|(%{release_name}%{?prerelease})|(Budgie Edition%{?prerelease})|g" %
 sed -e "s#\$version#%{bug_version}#g" -e 's/$edition/Budgie/;s/<!--.*-->//;/^$/d' %{SOURCE20} > %{buildroot}%{_swidtagdir}/org.ultramarinelinux.Ultramarine-edition.swidtag.budgie
 
 install -Dm0644 %{SOURCE60} %{buildroot}%{_sysconfdir}/dnf/protected.d/ultramarine-budgie.conf
-install -Dm0644 %{SOURCE100} %{buildroot}%{_libdir}/sddm/sddm.conf.d/budgie-sddm.conf
+install -Dm0644 %{SOURCE100} %{buildroot}/usr/lib/sddm/sddm.conf.d/budgie-sddm.conf
 %endif
 
 %if %{with atomic_budgie}
@@ -1132,7 +1132,7 @@ ln -sf firewalld-workstation.conf %{_sysconfdir}/firewalld/firewalld.conf
 %{_sysconfdir}/dnf/protected.d/ultramarine-budgie.conf
 %config %{_sysconfdir}/polycrystal/entries/ultramarine-budgie.json
 %{_sysconfdir}/lightdm/lightdm.conf.d/60-ultramarine-presets.conf
-%{_libdir}/sddm/sddm.conf.d/budgie-sddm.conf
+/usr/lib/sddm/sddm.conf.d/budgie-sddm.conf
 %endif
 
 %if %{with atomic_budgie}


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [lightdm wallpapers and budgie sddm (#412)](https://github.com/Ultramarine-Linux/packages/pull/412)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)