### PR TITLE
[um44] bump: umcli and install license (#416)

### DIFF
--- a/ultramarine/umcli/umcli.spec
+++ b/ultramarine/umcli/umcli.spec
@@ -5,8 +5,8 @@
 %global godocs          README.md
 
 Name:           umcli
-Version:        0.4.5
-Release:        2%{?dist}
+Version:        0.5.1
+Release:        1%{?dist}
 Summary:        A CLI tool for managing an Ultramarine Linux system
 
 License:        GPL-3.0-or-later
@@ -46,6 +46,7 @@ cp -av data/. %{buildroot}%{_datadir}/um/.
 
 %files
 %doc README.md
+%license LICENSE
 %{_bindir}/um
 %{_datadir}/um/
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [bump: umcli and install license (#416)](https://github.com/Ultramarine-Linux/packages/pull/416)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)