### PR TITLE
[um44] chore (release): only build on x86 runners (#419)

### DIFF
--- a/ultramarine/release/anda.hcl
+++ b/ultramarine/release/anda.hcl
@@ -1,4 +1,5 @@
 project "pkg" {
+        arches = ["x86_64"]
     rpm {
         spec = "ultramarine-release.spec"
         sources = "."


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [chore (release): only build on x86 runners (#419)](https://github.com/Ultramarine-Linux/packages/pull/419)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)