### PR TITLE
[um44] chore (comps): pull in ultramarine-backgrounds-kde for plasma (#425)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -395,6 +395,7 @@
       <!-- <packagereq type="default">haruna</packagereq> flatpak'd -->
       <!-- <packagereq type="default">kcalc</packagereq> flatpak'd -->
       <packagereq type="default">krdp</packagereq>
+      <packagereq type="default">ultramarine-backgrounds-kde</packagereq>
     </packagelist>
   </group>
   <environment>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [chore (comps): pull in ultramarine-backgrounds-kde for plasma (#425)](https://github.com/Ultramarine-Linux/packages/pull/425)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)