### PR TITLE
[umrawhide] fix(taidan-ultramarine-configs): detect-internet script bad syntax (#429)

### DIFF
--- a/ultramarine/taidan-ultramarine-configs/detect-internet
+++ b/ultramarine/taidan-ultramarine-configs/detect-internet
@@ -15,7 +15,7 @@ is_chromebook=$(has_pkg ultramarine-release-chromebook)
 is_surface=$(has_pkg ultramarine-release-surface)
 is_rpi=$(has_pkg ultramarine-release-raspberry_pi)
 
-curl -X POST https://plausible.fyralabs.com/api/event --json @- <<EOF
+curl -X POST https://plausible.fyralabs.com/api/event --json @- <<EOF || ping -c 1 -W 20 1.1.1.1 > /dev/null
 {
     "name": "pageview",
     "url": "app://internet/v0.2/$VERSION_ID",
@@ -28,4 +28,4 @@ curl -X POST https://plausible.fyralabs.com/api/event --json @- <<EOF
         "rpi": "$is_rpi"
     }
 }
-EOF || ping -c 1 -W 20 1.1.1.1 > /dev/null
+EOF

--- a/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
+++ b/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
@@ -1,6 +1,6 @@
 Name:           taidan-ultramarine-configs
 Version:        44
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Taidan configuration for Ultramarine
 License:        (MIT AND GPL-3.0-or-later)
 Provides:       taidan-configs


### PR DESCRIPTION
# Backport

This will backport the following commits from `um44` to `umrawhide`:
 - [fix(taidan-ultramarine-configs): detect-internet script bad syntax (#429)](https://github.com/Ultramarine-Linux/packages/pull/429)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)