### PR TITLE
bump appstream

### DIFF
--- a/ultramarine/ultramarine-appstream-metadata/ultramarine-appstream-metadata.spec
+++ b/ultramarine/ultramarine-appstream-metadata/ultramarine-appstream-metadata.spec
@@ -1,8 +1,8 @@
 Summary:        Operating System AppStream Metadata for Ultramarine Linux
 Name:           ultramarine-appstream-metadata
 # Use the time of the last metadata update as version
-Version:        20251125
-Release:        2%?dist
+Version:        20260702
+Release:        1%?dist
 License:        MIT
 URL:            https://ultramarine-linux.org/
 Source0:        https://github.com/Ultramarine-Linux/ultramarine-appstream-metadata/archive/refs/tags/%version.tar.gz


### PR DESCRIPTION
depends on https://github.com/Ultramarine-Linux/ultramarine-appstream-metadata/pull/1 and release