### PR TITLE
[um44] feat: move chromebook keyboard related services to main ultramarine preset (#442)

### DIFF
--- a/ultramarine/release/88-ultramarine-chromebook-default.preset
+++ b/ultramarine/release/88-ultramarine-chromebook-default.preset
@@ -1,10 +1,5 @@
 # Enable Ultramarine Chromebook Edition specific services in this file
 
-# Keyboard mappings
-enable cros-keyboard-map.service
-enable keyd.service #vhopefully will be replaced by croskbd soon
-enable croskbd.spec
-
 # USB-C fix on newer Chromebooks
 enable chromebook-usbc.service
 

--- a/ultramarine/release/89-ultramarine-default.preset
+++ b/ultramarine/release/89-ultramarine-default.preset
@@ -8,3 +8,8 @@ disable flatpak-add-fedora-repos.service
 
 # We use polycrystal to install Flatpaks
 enable polycrystal.service
+
+# Chromebook keyboard maps
+enable keyd.service # hopefully will be replaced by croskbd soon
+enable cros-keyboard-map.service
+enable croskbd.service

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -54,7 +54,7 @@
 Summary:	Ultramarine Linux release files
 Name:		ultramarine-release
 Version:	%{dist_version}
-Release:	8%{?dist}
+Release:	9%{?dist}
 License:	MIT
 Source0:	LICENSE
 URL:        https://ultramarine-linux.org


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [feat: move chromebook keyboard related services to main ultramarine preset (#442)](https://github.com/Ultramarine-Linux/packages/pull/442)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)