### PR TITLE
surface: tablet OSK, thermald, and auto-rotate defaults

### DIFF
--- a/ultramarine/release/50-surface-wayland-osk.conf
+++ b/ultramarine/release/50-surface-wayland-osk.conf
@@ -1,0 +1,8 @@
+# Wayland text-input for Chromium/Electron/QtWebEngine → GNOME OSK.
+# GTK/IBus IME steals focus and prevents the compositor OSK from showing.
+ELECTRON_OZONE_PLATFORM_HINT=wayland
+GTK_IM_MODULE=
+QT_IM_MODULE=
+XMODIFIERS=
+QT_IM_MODULES=wayland
+QTWEBENGINE_CHROMIUM_FLAGS=--ozone-platform=wayland --ozone-platform-hint=auto --enable-wayland-ime --wayland-text-input-version=3 --enable-features=WaylandTextInputV3 --disable-gtk-ime

--- a/ultramarine/release/91-ultramarine-surface-default.preset
+++ b/ultramarine/release/91-ultramarine-surface-default.preset
@@ -4,3 +4,7 @@
 enable surface-dtx-daemon.service
 enable surface-dtx-userd.service
 enable linux-surface-default-watchdog.path
+
+# Thermal management for sustained tablet/laptop loads
+enable thermald.service
+enable iio-sensor-proxy.service

--- a/ultramarine/release/99-surface-osk-ignore-virtual-keyboards.rules
+++ b/ultramarine/release/99-surface-osk-ignore-virtual-keyboards.rules
@@ -1,0 +1,10 @@
+# Fake/virtual key devices that suppress GNOME / Chromium on-screen keyboard.
+# ID_INPUT_KEYBOARD=0 alone is not enough — libinput still sets Capabilities:keyboard
+# from the key bitmask. LIBINPUT_IGNORE_DEVICE drops them from the seat.
+#
+# keyd virtual keyboard: always present when keyd runs; blocks tablet OSK.
+# Video Bus: ACPI brightness keys presented as a full keyboard.
+# gpio-keys: keep for volume/power — only clear KEYBOARD tag, do not ignore.
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="keyd virtual keyboard", ENV{ID_INPUT_KEYBOARD}="0", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Video Bus", ENV{ID_INPUT_KEYBOARD}="0", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="gpio-keys", ENV{ID_INPUT_KEYBOARD}="0"

--- a/ultramarine/release/gnome-auto-rotate
+++ b/ultramarine/release/gnome-auto-rotate
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Apply display transform from iio-sensor-proxy when GNOME auto-rotate is on.
+
+Used on Ultramarine Surface (GNOME Wayland) where built-in auto-rotate is
+unreliable and Touch Up's floating confirm button is undesirable.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+
+import gi
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib
+
+LOG = logging.getLogger("gnome-auto-rotate")
+
+ORIENT_TO_TRANSFORM = {
+    "normal": "normal",
+    "bottom-up": "180",
+    "left-up": "90",
+    "right-up": "270",
+}
+
+SENSOR_DEST = "net.hadess.SensorProxy"
+SENSOR_PATH = "/net/hadess/SensorProxy"
+SENSOR_IFACE = "net.hadess.SensorProxy"
+
+
+class AutoRotate:
+    def __init__(self) -> None:
+        self.bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        self.proxy = Gio.DBusProxy.new_sync(
+            self.bus,
+            Gio.DBusProxyFlags.NONE,
+            None,
+            SENSOR_DEST,
+            SENSOR_PATH,
+            SENSOR_IFACE,
+            None,
+        )
+        self.lock_settings = Gio.Settings.new(
+            "org.gnome.settings-daemon.peripherals.touchscreen"
+        )
+        self.current_transform: str | None = None
+        self._applying = False
+        self.lock_settings.connect("changed::orientation-lock", self._on_lock_changed)
+        self.proxy.connect("g-properties-changed", self._on_props)
+        self._claim_or_release()
+        for delay in (2, 5, 10, 20, 35):
+            GLib.timeout_add_seconds(delay, self._claim_or_release_once)
+
+    def orientation_locked(self) -> bool:
+        return bool(self.lock_settings.get_boolean("orientation-lock"))
+
+    def _claim_or_release_once(self) -> bool:
+        self._claim_or_release()
+        return False
+
+    def _on_lock_changed(self, *_args) -> None:
+        self._claim_or_release()
+
+    def _claim_or_release(self) -> None:
+        try:
+            has = bool(self.proxy.get_cached_property("HasAccelerometer").unpack())
+        except Exception:
+            has = True
+        if not has:
+            LOG.warning("No accelerometer")
+            return
+        if self.orientation_locked():
+            LOG.info("Orientation locked — releasing accelerometer")
+            try:
+                self.proxy.call_sync(
+                    "ReleaseAccelerometer", None, Gio.DBusCallFlags.NONE, -1, None
+                )
+            except Exception as e:
+                LOG.debug("Release: %s", e)
+            return
+        LOG.info("Auto-rotate on — claiming accelerometer")
+        try:
+            self.proxy.call_sync(
+                "ClaimAccelerometer", None, Gio.DBusCallFlags.NONE, -1, None
+            )
+        except Exception as e:
+            LOG.error("Claim failed: %s", e)
+            return
+        try:
+            prop = self.proxy.get_cached_property("AccelerometerOrientation")
+            if prop is not None:
+                self._apply(str(prop.unpack()))
+        except Exception as e:
+            LOG.debug("Initial orient: %s", e)
+
+    def _on_props(self, _proxy, changed, _invalidated) -> None:
+        if self.orientation_locked():
+            return
+        try:
+            d = changed.unpack()
+        except Exception:
+            return
+        if "AccelerometerOrientation" not in d:
+            return
+        orient = d["AccelerometerOrientation"]
+        if hasattr(orient, "unpack"):
+            orient = orient.unpack()
+        self._apply(str(orient))
+
+    def _apply(self, orientation: str) -> None:
+        transform = ORIENT_TO_TRANSFORM.get(orientation)
+        if transform is None or transform == self.current_transform or self._applying:
+            return
+        self._applying = True
+        try:
+            LOG.info("Rotating to %s (%s)", transform, orientation)
+            cmd = [
+                "gdctl",
+                "set",
+                "--logical-monitor",
+                "--primary",
+                "--monitor",
+                "eDP-1",
+                "--transform",
+                transform,
+            ]
+            scale = self._current_scale()
+            if scale is not None:
+                cmd.extend(["--scale", str(scale)])
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if r.returncode != 0:
+                LOG.error("gdctl failed: %s %s", r.stdout, r.stderr)
+            else:
+                self.current_transform = transform
+        except Exception as e:
+            LOG.error("apply failed: %s", e)
+        finally:
+            self._applying = False
+
+    def _current_scale(self) -> float | None:
+        try:
+            out = subprocess.check_output(["gdctl", "show"], text=True, timeout=5)
+            for line in out.splitlines():
+                if "Scale:" in line:
+                    return float(line.split("Scale:")[1].strip())
+        except Exception:
+            return 2.0
+        return 2.0
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stdout,
+    )
+    for _ in range(30):
+        if os.environ.get("WAYLAND_DISPLAY") or os.path.exists(
+            f"/run/user/{os.getuid()}/wayland-0"
+        ):
+            break
+        time.sleep(1)
+    if "WAYLAND_DISPLAY" not in os.environ and os.path.exists(
+        f"/run/user/{os.getuid()}/wayland-0"
+    ):
+        os.environ["WAYLAND_DISPLAY"] = "wayland-0"
+    if "XDG_RUNTIME_DIR" not in os.environ:
+        os.environ["XDG_RUNTIME_DIR"] = f"/run/user/{os.getuid()}"
+    if "DBUS_SESSION_BUS_ADDRESS" not in os.environ:
+        os.environ["DBUS_SESSION_BUS_ADDRESS"] = (
+            f"unix:path=/run/user/{os.getuid()}/bus"
+        )
+
+    AutoRotate()
+    LOG.info("gnome-auto-rotate started")
+    GLib.MainLoop().run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ultramarine/release/gnome-auto-rotate.service
+++ b/ultramarine/release/gnome-auto-rotate.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Auto-rotate display from iio-sensor-proxy (GNOME Wayland)
+Documentation=man:iio-sensor-proxy(8)
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/ultramarine-surface/gnome-auto-rotate
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/ultramarine/release/surface-electron-flags.conf
+++ b/ultramarine/release/surface-electron-flags.conf
@@ -1,0 +1,6 @@
+--ozone-platform-hint=auto
+--ozone-platform=wayland
+--enable-wayland-ime
+--wayland-text-input-version=3
+--enable-features=WaylandTextInputV3
+--disable-gtk-ime

--- a/ultramarine/release/surface-thermald-thermal-conf.xml
+++ b/ultramarine/release/surface-thermald-thermal-conf.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  Conservative thermald policy for Surface Pro 9 (and similar Intel Surface
+  tablets). Passiveraps RAPL / package power before the system hits sustained
+  high package temperatures under interactive load.
+
+  Install as /etc/thermald/thermal-conf.xml (packaged for ultramarine-release-surface).
+-->
+<ThermalConfiguration>
+  <Platform>
+    <Name>Surface Pro Family</Name>
+    <ProductName>*</ProductName>
+    <Preference>QUIET</Preference>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>cpu</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>x86_pkg_temp</SensorType>
+            <Temperature>75000</Temperature>
+            <type>passive</type>
+            <ControlType>PARALLEL</ControlType>
+            <CoolingDevice>
+              <index>1</index>
+              <type>rapl_controller</type>
+              <influence>50</influence>
+              <SamplingPeriod>5</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+          <TripPoint>
+            <SensorType>x86_pkg_temp</SensorType>
+            <Temperature>85000</Temperature>
+            <type>passive</type>
+            <ControlType>PARALLEL</ControlType>
+            <CoolingDevice>
+              <index>1</index>
+              <type>intel_pstate</type>
+              <influence>80</influence>
+              <SamplingPeriod>2</SamplingPeriod>
+            </CoolingDevice>
+            <CoolingDevice>
+              <index>2</index>
+              <type>rapl_controller</type>
+              <influence>100</influence>
+              <SamplingPeriod>2</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+  </Platform>
+</ThermalConfiguration>

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -117,6 +117,12 @@ Source64:   88-ultramarine-chromebook-default.preset
 
 Source65:   91-ultramarine-surface-default.preset
 Source66:   linux-surface.repo
+Source67:   99-surface-osk-ignore-virtual-keyboards.rules
+Source68:   50-surface-wayland-osk.conf
+Source69:   surface-electron-flags.conf
+Source74:   surface-thermald-thermal-conf.xml
+Source75:   gnome-auto-rotate
+Source76:   gnome-auto-rotate.service
 
 Source70:   polycrystal-ultramarine-budgie.json
 Source71:   polycrystal-ultramarine-gnome.json
@@ -669,9 +675,19 @@ Common configuration package for chromebook variants
 %if %{with surface}
 %package        surface
 Summary:        Common configuration package for surface variants
+Requires:       thermald
+Requires:       iio-sensor-proxy
+Requires:       python3-gobject
+# gdctl comes with mutter / gnome-console tooling on GNOME images
 
 %description surface
-Common configuration package for surface variants
+Common configuration package for Surface variants of Ultramarine Linux.
+
+Includes tablet-oriented defaults:
+- udev rules so keyd/Video Bus do not suppress the GNOME on-screen keyboard
+- Wayland text-input environment for Chromium/Electron/QtWebEngine
+- thermald policy tuned for sustained Surface loads
+- optional user service for accelerometer auto-rotate (gdctl)
 %endif
 
 ####### Raspberry Pi #######
@@ -1070,6 +1086,21 @@ install -Dm0644 %{SOURCE64} -t $RPM_BUILD_ROOT%{_prefix}/lib/systemd/system-pres
 install -Dm0644 %{SOURCE65} -t $RPM_BUILD_ROOT%{_prefix}/lib/systemd/system-preset/
 install -Dm0644 %{SOURCE66} -t $RPM_BUILD_ROOT/etc/yum.repos.d/
 
+# Tablet OSK / input quirks
+install -Dm0644 %{SOURCE67} -t $RPM_BUILD_ROOT%{_udevrulesdir}/
+install -Dm0644 %{SOURCE68} -t $RPM_BUILD_ROOT%{_prefix}/lib/environment.d/
+# Electron/Chromium flags (apps that honor *.conf under /etc or XDG config)
+install -Dm0644 %{SOURCE69} $RPM_BUILD_ROOT%{_sysconfdir}/electron-flags.conf
+install -Dm0644 %{SOURCE69} $RPM_BUILD_ROOT%{_sysconfdir}/chromium-flags.conf
+install -Dm0644 %{SOURCE69} $RPM_BUILD_ROOT%{_sysconfdir}/chrome-flags.conf
+
+# Thermald
+install -Dm0644 %{SOURCE74} $RPM_BUILD_ROOT%{_sysconfdir}/thermald/thermal-conf.xml
+
+# Auto-rotate helper (opt-in via user systemd)
+install -Dm0755 %{SOURCE75} $RPM_BUILD_ROOT%{_libexecdir}/ultramarine-surface/gnome-auto-rotate
+install -Dm0644 %{SOURCE76} -t $RPM_BUILD_ROOT%{_userunitdir}/
+
 %endif
 
 %if %{with raspberry_pi}
@@ -1291,6 +1322,14 @@ ln -sf firewalld-workstation.conf %{_sysconfdir}/firewalld/firewalld.conf
 %files surface
 %{_prefix}/lib/systemd/system-preset/91-ultramarine-surface-default.preset
 /etc/yum.repos.d//linux-surface.repo
+%{_udevrulesdir}/99-surface-osk-ignore-virtual-keyboards.rules
+%{_prefix}/lib/environment.d/50-surface-wayland-osk.conf
+%{_sysconfdir}/electron-flags.conf
+%{_sysconfdir}/chromium-flags.conf
+%{_sysconfdir}/chrome-flags.conf
+%{_sysconfdir}/thermald/thermal-conf.xml
+%{_libexecdir}/ultramarine-surface/gnome-auto-rotate
+%{_userunitdir}/gnome-auto-rotate.service
 %endif
 
 %if %{with raspberry_pi}


### PR DESCRIPTION
## Summary
Extends `ultramarine-release-surface` with tablet defaults validated on Surface Pro 9 (GNOME Wayland):

- **udev**: ignore `keyd virtual keyboard` / `Video Bus` in libinput so they do not suppress GNOME OSK (`ID_INPUT_KEYBOARD=0` alone is not enough)
- **environment.d + chrome/electron flags**: Wayland text-input + `--disable-gtk-ime` so Chromium/Electron/QtWebEngine drive the compositor OSK (same path Firefox/Zen already use)
- **thermald**: conservative passive policy for sustained package heat
- **gnome-auto-rotate** user unit: accelerometer → `gdctl` when GNOME auto-rotate is enabled (no Touch Up confirm button)
- **presets**: enable `thermald` and `iio-sensor-proxy`

## Test plan
- [ ] Build `ultramarine-release` with `--with surface`
- [ ] On Surface Pro 9 GNOME: confirm OSK can auto-show in Chrome/Electron after session reload
- [ ] Confirm volume keys still work (gpio-keys not ignored, only KEYBOARD tag cleared)
- [ ] `systemctl enable --now thermald` (or via preset on new image) — package temps stay saner under load
- [ ] `systemctl --user enable --now gnome-auto-rotate` — tilt rotates without floating button; respects orientation lock

## Notes
- Auto-rotate is **opt-in** via the user unit (not forced on every session) so Plasma/other editions are unaffected beyond the package contents.
- Related camera kernel work: https://github.com/linux-surface/linux-surface/pull/2227 (and front MIPI in linux-surface#2171)


Made with [Cursor](https://cursor.com)